### PR TITLE
Revert LKUP stats fix in V4 branch as not needed in V4

### DIFF
--- a/ASM/GVBMR95.asm
+++ b/ASM/GVBMR95.asm
@@ -1028,11 +1028,9 @@ done     ds    0h                 PARALLEL THREADS DONE
            basr  r14,r15
            larl  R15,owrt_report
            basr  R14,R15
-* only prepare lkup section if there are any lookups
-           if (ltgf,R1,lkuprec_cnt,p)
-             larl  r15,lkup_prepare
-             basr  r14,r15
-           endif 
+*
+           larl  r15,lkup_prepare
+           basr  r14,r15
            larl  r15,lkup_report
            basr  r14,r15
          endif
@@ -12954,7 +12952,7 @@ th_re                using logictbl,r15
                        mvi tkupEdate,c'N'
                      endif
 *
-                     aghi  r4,tkuprept_len next slot in table
+                     aghi  r4,tkuprept_len
                    endif  , not TOKN (i.e. fake lookup buffer)
 *
                  enddo  , ES lkup buffers
@@ -12965,8 +12963,6 @@ th_re                using logictbl,r15
 *   lookup buffer(s) that are stored somewhere in the literal pool
 *   based upon the literal pool header index associated with each RETK.
 *
-* Only do this if there are any lookups left - check the lkup count
-               if (cgf,R10,l,lkuprec_cnt)
 *           Look for any tokens associated with ES set
 th_retk        USING LOGICTBL,R15
                if ltgf,r15,th_es.ltesrtkq,p
@@ -12986,7 +12982,7 @@ th_retk        USING LOGICTBL,R15
                    drop  th_retk
 th_reet            using LOGICTBL,R15
                    lgf   r5,th_reet.ltlbanch
-                   if    tm,th_reet.ltesflg1,ltlbanco,o ltlbanch offset 
+                   if    tm,th_reet.ltesflg1,ltlbanco,o ltlbanch offset ?
                      agr   r5,r2
                      llgt  r5,0(r1,r5)
 *
@@ -13075,7 +13071,7 @@ th_reet            using LOGICTBL,R15
                  enddo  , RETK areas in queue
                  drop  th_reet
                endif
-               endif  - lkup count check
+
              enddo
            endif
          enddo
@@ -13329,7 +13325,7 @@ th_reet            using LOGICTBL,R15
            endif
          enddo
 
-         sty   r10,lkuprec_cnt    LKUP records
+         sty   r10,lkuprec_cnt    OWRT records
 
          lmg   R14,R12,SAVEZIIP   RESTORE RETURN ADDRESS
          br    R14


### PR DESCRIPTION
This reverts commit a077872415e11649825580d06b17a715e802f8eb, reversing changes made to 8e673522ff8892a17b26dcad77377ce1856430b9.